### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dotnet-build-test.yml
+++ b/.github/workflows/dotnet-build-test.yml
@@ -4,6 +4,7 @@
 name: Build and Test
 permissions:
   contents: read
+  pull-requests: write
 
 on:
   push:

--- a/.github/workflows/dotnet-build-test.yml
+++ b/.github/workflows/dotnet-build-test.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
 name: Build and Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Toenn-Vaot/toennvaotsystem/security/code-scanning/2](https://github.com/Toenn-Vaot/toennvaotsystem/security/code-scanning/2)

To fix this security issue, we need to explicitly define a `permissions` block at either the workflow or job level (since there is only one job, either is fine). The minimal permissions required to build and test code—when no write-back to the repository is expected—are `contents: read`. The best fix is to add the following at the workflow root, just after the `name` field and before `on`, so that all jobs (now and in the future) will inherit this minimal permission unless overridden. This change involves editing the `.github/workflows/dotnet-build-test.yml` file and inserting the following lines:

```yaml
permissions:
  contents: read
```

This is sufficient to resolve the CodeQL finding and to minimize privilege exposure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
